### PR TITLE
20.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koala-ui",
-  "version": "20.1.6",
+  "version": "20.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koala-ui",
-      "version": "20.1.6",
+      "version": "20.1.7",
       "dependencies": {
         "@angular/common": "^20.0.6",
         "@angular/compiler": "^20.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koala-ui",
-  "version": "20.1.6",
+  "version": "20.1.7",
   "scripts": {
     "ng": "ng",
     "start": "ng serve doc",

--- a/projects/koala-ui/core/koala-provider.ts
+++ b/projects/koala-ui/core/koala-provider.ts
@@ -27,7 +27,7 @@ interface KoalaSettings {
   hostApi?: string;
   language?: KoalaLanguage;
   httpClientErrorsMiddleware?: HttpClientErrorsMiddleware;
-  authConfig: AuthConfig;
+  authConfig?: AuthConfig;
   authorizationInterceptor?: HttpInterceptor;
 }
 


### PR DESCRIPTION
This pull request includes a version bump for the `koala-ui` package and a minor adjustment to the `KoalaSettings` interface to make the `authConfig` property optional.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `20.1.6` to `20.1.7`.

### Interface modification:
* [`projects/koala-ui/core/koala-provider.ts`](diffhunk://#diff-5b19421c66f10d29909874fd6a75d3ab16f1d33b1e669af59391c01572cffd37L30-R30): Made the `authConfig` property in the `KoalaSettings` interface optional, allowing greater flexibility in configurations.