### PR TITLE
20.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koala-ui",
-  "version": "20.2.1",
+  "version": "20.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koala-ui",
-      "version": "20.2.1",
+      "version": "20.2.2",
       "dependencies": {
         "@angular/common": "^20.0.6",
         "@angular/compiler": "^20.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koala-ui",
-  "version": "20.2.1",
+  "version": "20.2.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve doc",

--- a/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-value.ts
+++ b/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-value.ts
@@ -100,7 +100,7 @@ export class AutocompleteValue {
   }
 
   get hasValue() {
-    return this._hasValue();
+    return this._hasValue;
   }
 
   get currentValue() {
@@ -108,11 +108,11 @@ export class AutocompleteValue {
   }
 
   get selectedOption() {
-    return this._selectedOption();
+    return this._selectedOption;
   }
 
   get selectedOptions() {
-    return this._selectedOptions();
+    return this._selectedOptions;
   }
 
   get autofill() {


### PR DESCRIPTION
This pull request includes a version bump for the `koala-ui` package and a small refactor to the `AutocompleteValue` class to simplify property accessors.

Version update:

* Updated the `version` field in `package.json` from `20.2.1` to `20.2.2`.

Code refactor (AutocompleteValue):

* Changed the `hasValue`, `selectedOption`, and `selectedOptions` getters in `autocomplete-value.ts` to return internal properties directly instead of calling methods, simplifying the code and improving readability.