### PR TITLE
20.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koala-ui",
-  "version": "20.2.2",
+  "version": "20.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koala-ui",
-      "version": "20.2.2",
+      "version": "20.2.3",
       "dependencies": {
         "@angular/common": "^20.0.6",
         "@angular/compiler": "^20.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koala-ui",
-  "version": "20.2.2",
+  "version": "20.2.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve doc",

--- a/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-options.html
+++ b/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-options.html
@@ -4,7 +4,7 @@
   <div class="border-b border-neutral-200 dark:border-neutral-700">
     <label class="flex items-center text-sm">
       <i class="fa-solid fa-magnifying-glass opacity-60 absolute top-3 left-4"></i>
-      <input class="p-2 pr-3 pl-10 outline-none placeholder:opacity-60"
+      <input class="w-full p-2 pr-3 pl-10 outline-none placeholder:opacity-60"
         #searchInput
         type="search"
         [formControl]="autocompleteValue().filterControl"

--- a/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-options.ts
+++ b/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-options.ts
@@ -176,7 +176,10 @@ export class AutocompleteOptions implements OnInit, OnDestroy {
   };
 
   private close() {
-    if (this.autocompleteValue().filterControl.value) {
+    if (
+      this.autocompleteValue().filterControl.value &&
+      !this.autocompleteValue().isOnDemand()
+    ) {
       this.autocompleteValue().filterControl.reset();
     }
 

--- a/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-value.ts
+++ b/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete-value.ts
@@ -6,6 +6,7 @@ import {
   ResourceRef,
   signal,
   Signal,
+  WritableSignal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl } from '@angular/forms';
@@ -51,7 +52,7 @@ export class AutocompleteValue {
   private _autofill = signal<any | null>(null);
   private _isLoading?: Signal<boolean>;
   private _internalFilter = signal<string | null>(null);
-  private _isOnDemand?: Signal<boolean>;
+  private _isOnDemand?: WritableSignal<boolean>;
   private readonly _requestOptionsParams =
     signal<AutocompleteDataOptionsFnParams>({
       filter: null,
@@ -132,6 +133,32 @@ export class AutocompleteValue {
     }));
   }
 
+  get isOnDemand() {
+    if (!this._isOnDemand) {
+      return signal(false);
+    }
+    return this._isOnDemand.asReadonly();
+  }
+
+  private selectedOptionIsDiff(
+    options: AutocompleteOption | AutocompleteOption[]
+  ) {
+    if (this._multiple) {
+      return (
+        !Array.isArray(options) ||
+        options.length !== this._selectedOptions().length ||
+        options.some(
+          (opt, index) => opt.value !== this._selectedOptions()[index].value
+        )
+      );
+    }
+
+    return (
+      !options ||
+      (options as AutocompleteOption).value !== this._selectedOption()?.value
+    );
+  }
+
   private async selectOption(value: any) {
     while (this._isLoading!()) {
       await delay(100);
@@ -151,10 +178,14 @@ export class AutocompleteValue {
         autofill: value,
       }));
 
-      return this.makeAutofill();
+      await delay(100);
+
+      this.selectOption(value);
+
+      return;
     }
 
-    if (options) {
+    if (options && this.selectedOptionIsDiff(options)) {
       this._currentValue.update(() => {
         if (this._multiple) {
           if (Array.isArray(options)) {
@@ -199,7 +230,7 @@ export class AutocompleteValue {
     control: FormControl<any>,
     options: Signal<AutocompleteList>,
     isLoading: Signal<boolean>,
-    isOnDemand: Signal<boolean>,
+    isOnDemand: WritableSignal<boolean>,
     multiple = false
   ) {
     this._control = control;


### PR DESCRIPTION
This pull request introduces improvements to the autocomplete input field component in the Koala UI library, primarily focusing on better handling of "on-demand" option loading and selection logic. The changes enhance the user experience by ensuring the filter input resets only when appropriate and refine the internal state management for on-demand options.

**Autocomplete Option Handling Improvements:**

* The `close` method in `autocomplete-options.ts` now resets the filter input only if a filter value exists and the autocomplete is not in "on-demand" mode, preventing unwanted resets when options are loaded on demand.
* The `isOnDemand` property in `AutocompleteValue` is now a `WritableSignal<boolean>`, allowing for more flexible state updates and readonly access for consumers. [[1]](diffhunk://#diff-3f59111168e43ec7b32bbfe11984663b450fb9f5e2524e15564533b174796a71L54-R55) [[2]](diffhunk://#diff-3f59111168e43ec7b32bbfe11984663b450fb9f5e2524e15564533b174796a71L202-R233)
* Added a new `isOnDemand` getter to expose a readonly signal, improving encapsulation and usage clarity.

**Selection Logic Enhancements:**

* Introduced the `selectedOptionIsDiff` method to accurately detect changes in selected options, ensuring that updates only occur when the selection actually changes.
* Updated the `selectOption` method to use the new selection diff logic and improved async handling, preventing unnecessary updates and ensuring proper autofill behavior.

**UI/UX Fixes:**

* The search input in `autocomplete-options.html` now uses `w-full` to ensure it expands to the full width of its container, improving layout consistency.

**Miscellaneous:**

* Updated the package version in `package.json` to `20.2.3`.