### PR TITLE
22.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koala-ui",
-  "version": "20.2.5",
+  "version": "20.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koala-ui",
-      "version": "20.2.5",
+      "version": "20.2.6",
       "dependencies": {
         "@angular/common": "^20.0.6",
         "@angular/compiler": "^20.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koala-ui",
-  "version": "20.2.5",
+  "version": "20.2.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve doc",

--- a/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete.ts
+++ b/projects/koala-ui/shared/components/input-field/autocomplete/autocomplete.ts
@@ -81,7 +81,7 @@ export class Autocomplete {
       const percentFillOnScreen = (height * 100) / screenHeight;
 
       if (percentFillOnScreen <= 20) {
-        const optionsHeight = optionsContainer?.clientHeight || 0;
+        const optionsHeight = optionsContainer?.scrollHeight || 0;
         const currentHeight = optionsHeight + filterContainerHeight;
 
         if (optionsHeight > 0 && currentHeight <= maxHeight) {


### PR DESCRIPTION
This pull request includes a version bump for the `koala-ui` package and a minor fix to the Autocomplete component's dropdown height calculation.

Version update:

* Updated the package version in `package.json` from `20.2.5` to `20.2.6`.

Bug fix:

* In `autocomplete.ts`, changed the dropdown height calculation to use `scrollHeight` instead of `clientHeight` for more accurate sizing of the options container.